### PR TITLE
Require 'static for TStatusPayload of StatusOperationMessage

### DIFF
--- a/src/actors/packets/mod.rs
+++ b/src/actors/packets/mod.rs
@@ -81,7 +81,7 @@ fn schedule_status_check<TActor, TMessage, TStatusPayload, TStatusCheckFunc>(
     TMessage: Message + Send + 'static + Clone,
     TMessage::Result: Send,
     TActor::Context: ToEnvelope<TActor, TMessage>,
-    TStatusPayload: Send,
+    TStatusPayload: Send + 'static,
     TStatusCheckFunc: FnOnce(&Option<PacketStatus<TStatusPayload>>) -> bool + Send + 'static,
 {
     let error_recipient = error_recipient.clone();
@@ -136,7 +136,7 @@ where
     TMessage: Message + Send + 'static,
     TMessage::Result: Send,
     TActor::Context: ToEnvelope<TActor, TMessage>,
-    TStatusPayload: Send,
+    TStatusPayload: Send + 'static,
 {
     if let Err(e) = status_recipient.try_send(status_message) {
         let addr = ctx.address();
@@ -161,7 +161,7 @@ where
     TMessage: Message + Send + 'static,
     TMessage::Result: Send,
     TActor::Context: ToEnvelope<TActor, TMessage>,
-    TStatusPayload: Send,
+    TStatusPayload: Send + 'static,
 {
     if let Err(e) = status_recipient.try_send(StatusOperationMessage::RemovePacketStatus(id)) {
         let addr = ctx.address();


### PR DESCRIPTION
This crate currently relies on a bug in the compiler, and will stop compiling after https://github.com/rust-lang/rust/pull/118553.

The impl of `Message` for `StatusOperationMessage<T>` has a bound of `T: 'static`, but this isn't enforced on these functions. This is technically a breaking change, but should be required.